### PR TITLE
Appveyor script added

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
 - cd ..
 - wget http://dl.google.com/android/ndk/android-ndk-r10e-linux-x86_64.bin
 - chmod +x android-ndk-r10e-linux-x86_64.bin
-- sleep 360 && printf . & ./android-ndk-r10e-linux-x86_64.bin > log.txt
+- sleep 300 && printf . & sleep 600 && printf . & ./android-ndk-r10e-linux-x86_64.bin > log.txt
 - cd build_android
 - cmake ../fillwave -G"Eclipse CDT4 - Unix Makefiles" -DASSIMP_BUILD_TESTS=OFF -DASSIMP_BUILD_ASSIMP_TOOLS=OFF -DNDEBUG=OFF -D_ECLIPSE_VERSION="4.4" -DCMAKE_TOOLCHAIN_FILE=../fillwave/ext/android-cmake/android.toolchain.cmake -DANDROID_NDK=../android-ndk-r10e -DCMAKE_BUILD_TYPE=Release -DANDROID_ABI="armeabi-v7a with NEON" -DANDROID_NATIVE_API_LEVEL=18 && make -j4
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,6 @@
 
 [![Join the chat at https://gitter.im/filipwasil/fillwave](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/filipwasil/fillwave?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-![](https://travis-ci.org/filipwasil/fillwave.svg?branch=master)
-
-[![wercker status](https://app.wercker.com/status/176e362189e969142c07469b492ef216/m "wercker status")](https://app.wercker.com/project/bykey/176e362189e969142c07469b492ef216)
-
 [Fillwave] is a modern, native and totally free rendering engine writen in c++11 .
 
 Can be used in any 3D games, apps and visualization tools or as a regular part of your game engine.
@@ -18,9 +14,9 @@ Can be used in any 3D games, apps and visualization tools or as a regular part o
 - OpenGL ES 3.0 and OpenGL 3.3+ support with programmable pipeline
 - Engine can be fully open source and free under BSD license
 
-This wiki uses the [Markdown](http://daringfireball.net/projects/markdown/) syntax.
-
 # Building with cmake
+
+To build Fillwave you must have [CMake](https://cmake.org/), [GIT](https://git-scm.com/) and C++ comliers installed (So far, Clang and GCC are supported. MSVC version will be available soon). If you are not familiar with CMake I created few scripts to help you with building the project. Note that we use external libraries - each of them in separate git submodule.
 
 ```
 git clone https://github.com/filipwasil/fillwave.git
@@ -32,19 +28,38 @@ cd scripts
 
 ## Debian/Ubuntu/Fedora/RedHat
 
+Linux builds requires packages installed:
+
+```
+#Ubnuntu
+sudo apt-get install libglew1.10 libglew-dev libglfw3 libglfw3-dev libassimp3 libassimp-dev libfreetype6 libfreetype6-dev libglm-dev libx11-dev libglm-dev
+```
+
+```
+#Fedora
+sudo yum install glm-devel.x86_64 glm.x86_64 assimp.x86_64 assimp-devel.x86_64 glew.x86_64 glew-devel.x86_64 freetype-devel.x86_64 freetype.x86_64
+```
+
+
+Next, run build script:
+
 ```
 ./build_linux.sh
 ```
 
 ## Windows
 
+Windows build needs [MinGW](http://www.mingw.org/) installed (If you want to use pthreads then use [mingw64](http://mingw-w64.org/doku.php) version). Soon VS 14 2015 version will be also available.
+
 ```
-./build_windows.bat
+./build_windows_mingw.bat # ./build_windows_msvc will work soon
 ```
+
+Please also note that if you have sh.exe in your PATH, you should remove it for the compilation time. MinGW projects does not line sh.exe in PATH. Sorry.
 
 ## Android
 
-Script assumes that android NDK is under ~/Tools/android-ndk-r10e
+Android script is currently designed to work only with Linux. It assumes that Android [NDK] (http://developer.android.com/ndk/index.html) is under ~/Tools/android-ndk-r10e. If this is not true, update the script with correct path.
 
 ```
 ./build_android.sh
@@ -56,3 +71,11 @@ Script assumes that android NDK is under ~/Tools/android-ndk-r10e
 ```
 ./build_osx.sh
 ```
+
+--------------------------------------
+
+###Linux and Android ![](https://travis-ci.org/filipwasil/fillwave.svg?branch=master)
+
+###Windows [![Build status](https://ci.appveyor.com/api/projects/status/w5xqq2tntoo9td6k?svg=true)](https://ci.appveyor.com/project/filipwasil/fillwave)
+
+[![wercker status](https://app.wercker.com/status/176e362189e969142c07469b492ef216/m "wercker status")](https://app.wercker.com/project/bykey/176e362189e969142c07469b492ef216)

--- a/appveyor.cmake.py
+++ b/appveyor.cmake.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+# Build the project on AppVeyor.
+
+import os
+from subprocess import check_call
+
+build = os.environ['BUILD']
+config = os.environ['CONFIGURATION']
+platform = os.environ.get('PLATFORM')
+path = os.environ['PATH']
+cmake_command = ['cmake', '-DFMT_PEDANTIC=ON', '-DCMAKE_BUILD_TYPE=' + config, '-DASSIMP_BUILD_TESTS=OFF', '-DGLFW_BUILD_TESTS=OFF', '-DASSIMP_BUILD_ASSIMP_TOOLS=OFF', '-DGLFW_BUILD_EXAMPLES=OFF',  '-DGLFW_BUILD_DOCS=OFF']
+if build == 'mingw':
+  cmake_command.append('-GMinGW Makefiles')
+  build_command = ['mingw32-make', '-j4']
+  test_command = ['mingw32-make', 'test']
+  # Remove the path to Git bin directory from $PATH because it breaks MinGW config.
+  path = path.replace(r'C:\Program Files (x86)\Git\bin', '')
+  os.environ['PATH'] = r'C:\MinGW\bin;' + path
+else:
+  # Add MSBuild 14.0 to PATH as described in
+  # http://help.appveyor.com/discussions/problems/2229-v140-not-found-on-vs2105rc.
+  os.environ['PATH'] = r'C:\Program Files (x86)\MSBuild\14.0\Bin;' + path
+  generator = 'Visual Studio 14 2015'
+  if platform == 'x64':
+    generator += ' Win64'
+  cmake_command.append('-G' + generator)
+  build_command = ['msbuild', '/m:4', '/p:Config=' + config, 'FORMAT.sln']
+  test_command = ['msbuild', 'RUN_TESTS.vcxproj']
+
+check_call(cmake_command)
+check_call(build_command)
+check_call(test_command)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,19 @@
+configuration:
+  - Debug
+  - Release
+
+environment:
+  matrix:
+  #- BUILD: msvc
+  #- BUILD: msvc
+  #  PLATFORM: x64
+  - BUILD: mingw
+
+before_build:
+  # Workaround for CMake not wanting sh.exe on PATH for MinGW.
+  - git submodule init
+  - git submodule update
+  - set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
+
+build_script:
+  - python appveyor.cmake.py

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -6,6 +6,14 @@ if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
 endif()
 
+if(${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+endif()
+
+if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Intel")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+endif()
+
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__cplusplus=201103L")
         
 if(NOT FILLWAVE_SUPPRESS_WARNINGS)

--- a/cmake/platform/Windows.cmake
+++ b/cmake/platform/Windows.cmake
@@ -38,8 +38,16 @@ ADD_LIBRARY(fillwave SHARED ${FILLWAVE_SOURCES})
 # Linker
 # -----------------------------------------------
 
-ADD_DEPENDENCIES(fillwave ${FILLWAVE_MODEL_LOADER} fontgenerator glew64)
-TARGET_LINK_LIBRARIES(fillwave ${FILLWAVE_MODEL_LOADER} fontgenerator glew64)
+if( CMAKE_SIZEOF_VOID_P EQUAL 4 )
+    set( FILLWAVE_GLEW_BUILD glew32 )
+elseif( CMAKE_SIZEOF_VOID_P EQUAL 8 )
+    set( FILLWAVE_GLEW_BUILD glew64 )
+else()
+    message( FATAL_ERROR "Data width could not be determined!" )
+endif()
+
+ADD_DEPENDENCIES(fillwave ${FILLWAVE_MODEL_LOADER} fontgenerator ${FILLWAVE_GLEW_BUILD})
+TARGET_LINK_LIBRARIES(fillwave ${FILLWAVE_MODEL_LOADER} fontgenerator ${FILLWAVE_GLEW_BUILD})
  
 # -----------------------------------------------
 # Installation

--- a/scripts/build_windows-mingw.bat
+++ b/scripts/build_windows-mingw.bat
@@ -1,6 +1,7 @@
 cd ../..
 IF exist fillwave_windows_build ( echo directory exists ) ELSE ( mkdir fillwave_windows_build && echo fillwave_windows_build created)
 cd fillwave_windows_build
+set path=%path:C:/mingw64/bin;=%
 cmake ../fillwave -G "Eclipse CDT4 - MinGW Makefiles" -DASSIMP_BUILD_TESTS=OFF -DGLFW_BUILD_TESTS=OFF -DASSIMP_BUILD_ASSIMP_TOOLS=OFF -DGLFW_BUILD_EXAMPLES=OFF -DGLFW_BUILD_DOCS=OFF
 mingw32-make -j4
 cpack

--- a/scripts/build_windows_msvc.bat
+++ b/scripts/build_windows_msvc.bat
@@ -1,0 +1,7 @@
+cd ../..
+IF exist fillwave_windows_build_vs ( echo directory exists ) ELSE ( mkdir fillwave_windows_build_vs && echo fillwave_windows_build_vs created)
+mkdir fillwave_windows_build_vs
+cd fillwave_windows_build_vs
+cmake ../fillwave -G "Visual Studio 14 2015" -DASSIMP_BUILD_ASSIMP_TOOLS=NO -DBUILD_SHARED_LIBS:BOOL=false -DASSIMP_BUILD_TESTS=OFF -DASSIMP_BUILD_TESTS=OFF -DGLFW_BUILD_TESTS=OFF -DASSIMP_BUILD_ASSIMP_TOOLS=OFF -DGLFW_BUILD_EXAMPLES=OFF -DGLFW_BUILD_DOCS=OFF
+cmake --build .
+pause

--- a/test_android/appveyor.setup.bat
+++ b/test_android/appveyor.setup.bat
@@ -1,0 +1,10 @@
+powershell -Command "(New-Object Net.WebClient).DownloadFile('http://downloads.sourceforge.net/project/mingw-w64/mingw-w64/mingw-w64-release/mingw-w64-v4.0.4.tar.bz2?r=&ts=1447082361&use_mirror=skylink', 'mingw64.tar.bz2')"
+tar xjvf mingw64.tar.bz2 -C %mypath:~0,-1%\mingw64
+SET mypath=%~dp0
+echo %mypath:~0,-1%
+setx PATH "%PATH%;%mypath:~0,-1%\mingw64\bin"
+IF exist fillwave_windows_build ( echo directory exists ) ELSE ( mkdir fillwave_windows_build && echo fillwave_windows_build created)
+cd fillwave_windows_build
+cmake ../fillwave -G "Eclipse CDT4 - MinGW Makefiles" -DASSIMP_BUILD_TESTS=OFF -DGLFW_BUILD_TESTS=OFF -DASSIMP_BUILD_ASSIMP_TOOLS=OFF -DGLFW_BUILD_EXAMPLES=OFF -DGLFW_BUILD_DOCS=OFF
+mingw32-make -j4
+pause


### PR DESCRIPTION
Created CI script for AppVeyor
- Updated Readme
- updated Windows build with architecture (32b vs 64b) detection
- Crated CI scripts for AppVeyor (python based)
- Travis timeout workaround
